### PR TITLE
Fix for extensive sweep missing combinations.

### DIFF
--- a/factorio_balancers/balancer.py
+++ b/factorio_balancers/balancer.py
@@ -498,7 +498,7 @@ class Balancer(Blueprint):
         if extensive:
             i_range = range(
                 1,
-                min(
+                1 + min(
                     len(self._input_belts),
                     len(self._output_belts)))
             nr_of_permutations = get_nr_of_permutations(


### PR DESCRIPTION
As reported in this issue: https://github.com/tzwaan/factorio_balancers/issues/5#issue-742905221 1 needs to be added to the upper limit of the range for doing extensive sweeps to make in inclusive, otherwise it misses tests with inputs and outputs matching the minimum of the inputs or outputs.